### PR TITLE
parameter 'r' was unused in getDefaultPage function

### DIFF
--- a/godin.go
+++ b/godin.go
@@ -83,7 +83,7 @@ func main() {
 
 }
 
-func getDefaultPage(w http.ResponseWriter, r *http.Request) {
+func getDefaultPage(w http.ResponseWriter) {
 	w.Write([]byte("Godin"))
 }
 


### PR DESCRIPTION
Unused parameters in functions or methods should be removed to prevent potential bug risk